### PR TITLE
Update to rights statements as of 2015-07-15

### DIFF
--- a/rights-statements.ttl
+++ b/rights-statements.ttl
@@ -44,7 +44,7 @@
 <collection-pd> a skos:Collection ;
   skos:prefLabel "public domain statements"@en ;
   skos:member <pd-nc> ;
-  skos:member <pd-contractual-restriction> ;
+  skos:member <pd-contractual-restrictions> ;
   skos:member <pd-other-legal-restrictions> .
 
 <collection-und> a skos:Collection ;
@@ -53,43 +53,87 @@
   skos:member <und> .
 
 # Individual statements
+# 2015-07-15: updated from https://docs.google.com/document/d/1tdRAFZZefiyygRwCbcUq-kK7mNdj-6UFwBSCrPRSIoY/edit
 
 <ic> a dcterms:RightsStatement ;
   skos:prefLabel "In Copyright"@en ;
-  dcterms:modified "2015-05-11" ;
+  dcterms:modified "2015-07-15" ;
   skos:closeMatch <http://www.europeana.eu/rights/rr-f/> ;
-  skos:definition "Indicates that the work labeled with this rights statement is in copyright (no intention or ability to license)."@en ;
+  skos:definition """This item is protected by copyright and/or related rights.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you.
+
+For other uses you need to obtain permission from the rightsholders.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available."""@en ;
+  skos:scopeNote "This rights statement can be used for any work that is in copyright. Using this statement implies that the the organisation making this item available has determined that the item is in copyright and; is either the copyright holder, has obtained permission to make available the work from the copyright holder or, makes the work available under an exception or limitation to copyright (including fair use) that entitles it to make the work available."@en ;
   skos:relatedMatch premiscopy:cpr ;
   dcterms:hasVersion "1.0" ;
   dcterms:creator <irswg> ;
-  dc:identifier "ic" ;
+  dc:identifier "InC" ;
   skos:inScheme <> .
 
 <ic-ow-eu> a dcterms:RightsStatement ;
-  skos:prefLabel "In Copyright - Orphan Works - EU"@en ;
-  dcterms:modified "2015-05-11" ;
+  skos:prefLabel "In Copyright - EU Orphan Work"@en ;
+  dcterms:modified "2015-07-15" ;
   skos:closeMatch <http://www.europeana.eu/rights/orphan-work-eu/> ;
-  skos:definition "Indicates that the work labeled with this rights statement has been identified as an orphan work under the terms of the EU Orphan works directive."@en ;
+  skos:definition """This item has been identified as an orphan work in the country of first publication and in line Directive 2012/28/EU of the European Parliament and of the Council of 25 October 2012 on certain permitted uses of orphan works.
+
+For this item no rightholder(s) have been identified or, if one or more of them have been identified, none has been located despite a diligent search for the rightholders having been carried out. The results of the diligent search are available in the EU orphan works database.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* If you have any information related to the copyright status of the item that can contribute to identifying or locating the rightsholder please notify the organisation that has made the item available.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available."""@en ;
+  skos:scopeNote "This rights statement is intended for use with works that have been identified as Orphan Works in accordance with in line Directive 2012/28/EU of the European Parliament and of the Council of 25 October 2012 on certain permitted uses of orphan works. It can only be applied to works that are covered by the directive: works published in the form of books, journals, newspapers, magazines or other writings as well as cinematographic or audiovisual works and phonograms (note that this excludes photography and visual arts). It can only applied by data providers that are beneficiaries of the directive: publicly accessible libraries, educational establishments and museums, archives, film or audio heritage institutions and public-service broadcasting organisations, established in one of the EU member states. The beneficiary is also expected to have registered the work in the EU Orphan Works Database maintained by OHIM."@en ;
   skos:relatedMatch premiscopy:cpr ;
   dcterms:creator <irswg> ;
   dcterms:hasVersion "1.0" ;
-  dc:identifier "ic-ow-eu" ;
+  dc:identifier "InC-OW-EU" ;
   skos:inScheme <> .
 
 <ic-couu> a dcterms:RightsStatement ;
   skos:prefLabel "In Copyright - Copyright Owner Unlocatable or Unidentifiable"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work labeled with this rights statement has been identified as in copyright, but whose owner either cannot be identified or cannot be located."@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """This item is protected by copyright and/or related rights. However, no rightsholder(s) have been identified, or, if one or more of them have been identified, none has been located.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* If you have any information related to the copyright status of the item that can contribute to identifying or locating the rightsholder please notify the organisation that has made the item available.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement is intended for use with works that have been identified as Orphan Works by the data provider after a diligent search has taken place. This rights statement should only be used if the data provider is reasonably sure that the work is in copyright. This rights statement is not intended for use by EU based data providers who have identified works as Orphan works in accordance with the EU orphan works directive (they must use IC-OW-EU instead)."@en ;
   skos:relatedMatch premiscopy:cpr ;
   dcterms:creator <irswg> ;
   dcterms:hasVersion "1.0" ;
-  dc:identifier "ic-couu" ;
+  dc:identifier "InC-RUU" ;
   skos:inScheme <> .
 
 <ic-edu> a dcterms:RightsStatement ;
-  skos:prefLabel "Copyright - Educational Use Only"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work labeled with this rights statement is in copyright but that educational use is allowed without the need to obtain additional permission."@en ;
+  skos:prefLabel "In Copyright - Educational Use Permitted"@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """This item is protected by copyright and/or related rights.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you. In addition, for educational uses, no permission is required from the rightsholders.
+
+For other uses you need to obtain permission from the rightsholders.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement can be used for any in copyright work. However it can only be applied to works where the organisation submitting the item is the rightsholder or where the institution submitting the item has been explicitly authorized by the rightsholder(s) to allow third parties to use the work for educational purposes without obtaining permission first."@en ;
   odrl:permission [
     odrl:action odrl:use ;
     odrl:constraint [
@@ -100,66 +144,108 @@
   skos:relatedMatch premiscopy:cpr ;
   dcterms:creator <irswg> ;
   dcterms:hasVersion "1.0" ;
-  dc:identifier "ic-edu" ;
+  dc:identifier "InC-EDU" ;
   skos:inScheme <> .
 
 <ic-nc> a dcterms:RightsStatement ;
-  skos:prefLabel "In Copyright - Non-Commercial Use Only"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work labeled with this rights statement is in copyright but that non-commercial use is allowed without the need to obtain additional permission."@en ;
+  skos:prefLabel "In Copyright - NonCommercial Use Permitted"@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """This item is protected by copyright and/or related rights.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you. In addition, for all non-commercial uses, no permission is required from the rightsholders.
+
+For other uses you need to obtain permission from the rightsholders.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement can be used for any in copyright work. However it can only be applied to works where the organisation submitting the item is the rights holder or where the institution submitting the item has been explicitly authorized by the rights holder(s) to allow third parties to use the work for non-commercial purposes without obtaining permission first."@en ;
   cc:prohibits cc:CommercialUse ;
   skos:closeMatch <http://creativecommons.org/licenses/by-nc/4.0/> ;
   skos:relatedMatch premiscopy:cpr ;
   dcterms:creator <irswg> ;
   dcterms:hasVersion "1.0" ;
-  dc:identifier "ic-nc" ;
-  skos:inScheme <> .
-
-<ic-permission> a dcterms:RightsStatement ;
-  skos:prefLabel "In Copyright - Permissive Uses Available"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work labeled with this rights statement is in copyright and that the organization that has published the work is willing to grant licenses for use by third parties."@en ;
-  skos:relatedMatch premiscopy:cpr ;
-  dcterms:creator <irswg> ;
-  dcterms:hasVersion "1.0" ;
-  dc:identifier "ic-permission" ;
+  dc:identifier "InC-NC" ;
   skos:inScheme <> .
 
 <pd-nc> a dcterms:RightsStatement ;
-  skos:prefLabel "Public Domain - Non-Commercial Use Only"@en ;
-  dcterms:modified "2015-05-11";
-  skos:definition "Indicates that the work is in the public domain, but  the organization that has published the work is contractually required to only allow non-commercial use by third parties."@en ;
+  skos:prefLabel "Out Of Copyright - NonCommercial Use Only"@en ;
+  dcterms:modified "2015-07-15";
+  skos:definition """This object has been digitized in a public-private partnership. As part of this partnership, the partners have agreed to limit commercial uses of￼this digital representation of the object by third parties [until the year￼xxxx].￼
+
+You can, without permission, copy, modify, distribute, display, or perform the digital object, for non-commercial uses. For any other permissible uses, please review the terms and conditions of the Data￼Provider.
+
+In some jurisdictions moral rights of the author may persist beyond the term of copyright. These rights may include the right to be identified as ￼the author and the right to object to derogatory treatments. When using this digital object please respect Europeana's usage Guidelines for public domain works."""@en ;
+  skos:scopeNote "This rights statement can only be used for works that are in the Public Domain and have been digitized in a public-private partnership as part of which, the partners have agreed to limit commercial uses of ￼this digital representation of the object by third parties. It has been developed specifically to allow the inclusion of works that have been digitized as part of the partnerships between European Libraries and Google, but can in theory be applied to works that have been digitized in similar public private partnerships."@en ;
   cc:prohibits cc:CommercialUse ;
   skos:relatedMatch premiscopy:pub ;
   dcterms:creator <irswg> ;
   dcterms:hasVersion "1.0" ;
-  dc:identifier "pd-nc" ;
+  dc:identifier "OOC-NC" ;
   skos:inScheme <> .
 
-<pd-contractual-restriction> a dcterms:RightsStatement ;
-  skos:prefLabel "Public Domain - Contractual Restrictions Present"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work is in the public domain, but that the organization that has published the work is contractually required to restrict certain forms of use by third parties."@en ;
+<pd-contractual-restrictions> a dcterms:RightsStatement ;
+  skos:prefLabel "No Copyright - Contractual Restrictions Present"@en ;
+  dcterms:modified "2015-07-15" ;
+  # per pk comment on 2015-07-15 Dave and Diane are editing the text below
+  skos:definition """This item is not covered by copyright and/or related rights.
+
+As part of the acquisition or digitisation of this item, the organisation that has made the item available is contractually required to limit the use of this item. Limitations may be due to privacy issues, cultural protections, or donor agreements.
+
+Please refer to the organisation that has made the item available for more information.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement can only be used for items that are in the Public Domain but where the data provider has entered into contractual agreement that limits third party uses of the item. In order for this rights statement to be conclusive the data provider must provide a link to a page detailing the the contractual restrictions that apply to the use of the item."@en ;
   skos:relatedMatch premiscopy:pub ;
   dcterms:hasVersion "1.0" ;
   dcterms:creator <irswg> ;
-  dc:identifier "pd-contractual-restriction" ;
+  dc:identifier "NoC-CR" ;
   skos:inScheme <> .
 
 <pd-other-legal-restrictions> a dcterms:RightsStatement ;
-  skos:prefLabel "Public Domain - Other Legal Restrictions"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the work is in the public domain, but that laws other than copyright impose restrictions on the use of the object by third parties."@en ;
+  skos:prefLabel "No Copyright - Other Legal Restrictions"@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """This item is not covered by copyright and/or related rights.
+
+In one or more jurisdictions, laws other than copyright impose restrictions on the use of this item.
+
+Please refer to the organisation that has made the item available for more information.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement should be used for items that are in the Public Domain but that cannot be freely reused as the consequence of other legal restrictions that prevent the data provider from allowing free re-use of the work. In order for this rights statement to be conclusive the data provider must provide a link to a page detailing the the legal restrictions that limit re-use of the item."@en ;
   skos:relatedMatch premiscopy:pub ;
   dcterms:hasVersion "1.0" ;
   dcterms:creator <irswg> ;
-  dc:identifier "pd-other-legal-restrictions" ;
+  dc:identifier "NoC-OLR" ;
   skos:inScheme <> .
 
 <nkr> a dcterms:RightsStatement ;
-  skos:prefLabel "No Known Rights"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "Indicates that the data provider believes that no copyright or related rights are known to exist for this work, but conclusive facts may be missing or ambiguous."@en ;
+  skos:prefLabel "No Known Copyright"@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """The organisation that has made available the item reasonably believes that no copyright or related rights are known to exist in this item, but a conclusive determination could not be made. Please refer to the organisation that has made the item available for more information.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement should be used for items where the copyright status has not been determined conclusively, but where the data provider has reasonable cause to believe that the work is not covered by copyright or related rights anymore. This rights statement should not be used for orphan works (which are assumed to be in copyright) or for works where the data provider has not undertaken an effort to ascertain the copyright status of the work."@en ;
   skos:relatedMatch premiscopy:unk ;
   dcterms:hasVersion "1.0" ;
   dcterms:creator <irswg> ;
@@ -167,12 +253,22 @@
   skos:inScheme <> .
 
 <und> a dcterms:RightsStatement ;
-  skos:prefLabel "Rights Undetermined"@en ;
-  dcterms:modified "2015-05-11" ;
-  skos:definition "The copyright and related rights status of this work is unknown."@en ;
+  skos:prefLabel "Copyright Not Evaluated "@en ;
+  dcterms:modified "2015-07-15" ;
+  skos:definition """The copyright and related rights status of this item has not been evaluated. Please refer to the organisation that has made the item available for more information.
+
+You are free to use this item in any way that is permitted by the copyright and related rights legislation that applies to you.
+
+Notices:
+
+* Unless expressly stated otherwise, the organisation that has made this item available makes no warranties about the item. You are responsible for your own use.
+* You may need to obtain other permissions for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+* You may find additional information about the copyright status of the item on the website of the organisation that has made the item available.
+"""@en ;
+  skos:scopeNote "This rights statement should be used for items where the copyright status is unknown and where the data provider not undertaken an effort to determine the copyright status of the work."@en ;
   skos:closeMatch <http://www.europeana.eu/rights/unknown/> ;
   skos:relatedMatch premiscopy:unk ;
   dcterms:hasVersion "1.0" ;
   dcterms:creator <irswg> ;
-  dc:identifier "und" ;
+  dc:identifier "CNE" ;
   skos:inScheme <> .


### PR DESCRIPTION
- Rights statements updated from the Google Docs version.
- Adds `skos:scopeNote` where appropriate to inform implementers
  about the purpose for a given statement.
- Changes identifiers based upon document. Per @musebrarian's
  comment we may want to make these consistent with the URIs.
